### PR TITLE
Add asynchronous loading method to pull data over-the-air via URLSess…

### DIFF
--- a/Source/Common/GLTFSceneSource.swift
+++ b/Source/Common/GLTFSceneSource.swift
@@ -37,6 +37,50 @@ public class GLTFSceneSource : SCNSceneSource {
         }
     }
     
+    public static func load(remoteURL: URL,
+                            onSuccess success: @escaping (_ sceneSource: GLTFSceneSource) -> Void,
+                            onFailure failure: Optional<(_ error: Error) -> Void> = nil,
+                            extensions: [String:Codable.Type]? = nil) -> URLSessionDataTask {
+        
+        struct UnexpectedResponseError: Error {
+            enum ErrorType {
+                case unexpectedResponseType
+                case noData
+                indirect case status(Int)
+            }
+            
+            let errorType: ErrorType
+        }
+
+        let dataTask = URLSession.shared.dataTask(with: remoteURL) { data, response, error in
+            // Handle various error cases
+            if let error = error {
+                failure?(error)
+                return
+            }
+            
+            guard let httpResponse = response as? HTTPURLResponse else {
+                failure?(UnexpectedResponseError(errorType: .unexpectedResponseType))
+                return
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                failure?(UnexpectedResponseError(errorType: .status(httpResponse.statusCode)))
+                return
+            }
+            
+            // Construct object and return
+            guard let data = data else {
+                failure?(UnexpectedResponseError(errorType: .noData))
+                return
+            }
+            success(GLTFSceneSource.init(data: data))
+        }
+        dataTask.resume()
+        
+        return dataTask
+    }
+
     public override convenience init(data: Data, options: [SCNSceneSource.LoadingOption : Any]? = nil) {
         self.init()
         do {

--- a/Source/Common/GLTFSceneSource.swift
+++ b/Source/Common/GLTFSceneSource.swift
@@ -74,7 +74,7 @@ public class GLTFSceneSource : SCNSceneSource {
                 failure?(UnexpectedResponseError(errorType: .noData))
                 return
             }
-            success(GLTFSceneSource.init(data: data))
+            success(GLTFSceneSource(data: data))
         }
         dataTask.resume()
         


### PR DESCRIPTION
This method allows for fixing #[50](https://github.com/Svrf/svrf-ios-sdk/issues/50)
- Creates an asynchronous load for remote URLs
- Returns a dataTask to be propagated back up for query management
- Please don't use the other loaders for remote URLs any more!! Thanks :) 

(Also I'm pretty new to Swift, so thx for bearing with being a little slow on conventions - in particular I'm not totally convinced by the structure of the error handling here!)