### PR TITLE
Safer loading; set directoryPath for URL params

### DIFF
--- a/Source/Common/GLTFErrors.swift
+++ b/Source/Common/GLTFErrors.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+public enum GLTFLoadingError: Error {
+    case LoaderNotInitialized
+}
+
 public enum GLTFUnarchiveError: Error {
     case DataInconsistent(String)
     case NotSupported(String)

--- a/Source/Common/GLTFSceneSource.swift
+++ b/Source/Common/GLTFSceneSource.swift
@@ -17,7 +17,7 @@ public class GLTFSceneSource : SCNSceneSource {
             return self.loader != nil
         }
     }
-    
+
     public override init() {
         super.init()
     }
@@ -58,7 +58,7 @@ public class GLTFSceneSource : SCNSceneSource {
             
             let errorType: ErrorType
         }
-
+        
         let dataTask = URLSession.shared.dataTask(with: remoteURL) { data, response, error in
             // Handle various error cases
             if let error = error {
@@ -82,7 +82,8 @@ public class GLTFSceneSource : SCNSceneSource {
                 return
             }
 
-            let sceneSource = GLTFSceneSource(data: data, animationManager: animationManager)
+            let directoryPath = httpResponse.url?.deletingLastPathComponent()
+            let sceneSource = GLTFSceneSource(data: data, withDirectoryPath: directoryPath, animationManager: animationManager)
             success(sceneSource)
         }
         dataTask.resume()
@@ -91,11 +92,12 @@ public class GLTFSceneSource : SCNSceneSource {
     }
 
     public convenience init(data: Data,
+                            withDirectoryPath directoryPath: URL? = nil,
                             animationManager: GLTFAnimationManager? = nil,
                             options: [SCNSceneSource.LoadingOption : Any]? = nil) {
         self.init()
         do {
-            self.loader = try GLTFUnarchiver(data: data, animationManager: animationManager)
+            self.loader = try GLTFUnarchiver(data: data, withDirectoryPath: directoryPath, animationManager: animationManager)
         } catch {
             print("\(error.localizedDescription)")
         }

--- a/Source/Common/GLTFSceneSource.swift
+++ b/Source/Common/GLTFSceneSource.swift
@@ -12,6 +12,11 @@ import SpriteKit
 @objcMembers
 public class GLTFSceneSource : SCNSceneSource {
     private var loader: GLTFUnarchiver! = nil
+    public var loaded: Bool {
+        get {
+            return self.loader != nil
+        }
+    }
     
     public override init() {
         super.init()
@@ -105,6 +110,10 @@ public class GLTFSceneSource : SCNSceneSource {
     }
     
     public override func scene(options: [SCNSceneSource.LoadingOption : Any]? = nil) throws -> SCNScene {
+        guard self.loaded else {
+            throw GLTFLoadingError.LoaderNotInitialized
+        }
+
         let scene = try self.loader.loadScene()
         #if SEEMS_TO_HAVE_SKINNER_VECTOR_TYPE_BUG
             let sceneData = NSKeyedArchiver.archivedData(withRootObject: scene)

--- a/Source/Common/GLTFUnarchiver.swift
+++ b/Source/Common/GLTFUnarchiver.swift
@@ -69,11 +69,11 @@ public class GLTFUnarchiver {
     
     convenience public init(url: URL, extensions: [String:Codable.Type]? = nil) throws {
         let data = try Data(contentsOf: url)
-        try self.init(data: data, extensions: extensions)
-        self.directoryPath = url.deletingLastPathComponent()
+        try self.init(data: data, withDirectoryPath: url.deletingLastPathComponent(), extensions: extensions)
     }
     
-    public init(data: Data, animationManager: GLTFAnimationManager? = nil, extensions: [String:Codable.Type]? = nil) throws {
+    public init(data: Data, withDirectoryPath: URL? = nil, animationManager: GLTFAnimationManager? = nil, extensions: [String:Codable.Type]? = nil) throws {
+        self.directoryPath = withDirectoryPath
         let decoder = JSONDecoder()
         var _extensions = extensionList
         extensions?.forEach { (ext) in _extensions[ext.key] = ext.value }


### PR DESCRIPTION
This diff adds a `.loaded` computed var that returns true if the loader is not nil. The original lib didn't expose the loader, which seems reasonable, so I kept that pattern.

The other addition is that the `GLTFUnarchiver.directoryPath` can optionally be set when initialized with `Data`. This is mostly to allow `GLTFUnarchiver.load` to fetch the gltf file in the background and the fetching can be cancelled. Eventually I would like to have all of the other assets load asynchronously, however the delay time is good pressure to have more performant models.